### PR TITLE
Update Fiat Panda generations: add Grande Panda (2024) and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Fiat Panda
 
+This repository contains signal set configurations for the Fiat Panda, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Fiat Panda.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Fiat_Panda"
+
 generations:
   - name: "First Generation (Type 141)"
     start_year: 1980
@@ -13,3 +16,8 @@ generations:
     start_year: 2011
     end_year: null
     description: "The current Panda built upon its predecessor's strengths while offering improved quality, technology, and safety. Slightly larger with a more evolved design, it maintained the 'squircle' theme throughout the interior and exterior. Engine options have included the innovative two-cylinder TwinAir turbocharged engine, conventional 1.2L four-cylinder petrol units, and 1.3L MultiJet diesels. The Panda 4×4 continued as the world's smallest off-roader with genuine capability thanks to its lightweight, electronic differential locks, and specialized traction systems. Special variants have included the Cross with enhanced off-road styling and capability, the Hybrid with mild-hybrid technology, and the City Cross offering crossover styling with two-wheel drive. The interior focuses on practicality with flexible seating, numerous storage compartments, and modern connectivity options. Despite its age, the third-generation Panda remains popular for its combination of city-friendly dimensions, practical design, and unique character, continuing as one of Fiat's core models with over 7.5 million Pandas produced across all generations."
+
+  - name: "Grande Panda (Type 326)"
+    start_year: 2024
+    end_year: null
+    description: "The Grande Panda was introduced on 14 June 2024 as a B-segment version of the Panda, representing a larger upgrade from the classic city car size. Based on the Smart Car platform shared with the fourth-generation Citroën C3 and Opel Frontera, the Grande Panda offers a new dimension to the Panda family. It is sold with mild hybrid and fully electric powertrains, providing modern sustainable options while maintaining the Panda's iconic design language and practical philosophy."


### PR DESCRIPTION
- Added references array with Wikipedia source URL
- Added fourth generation: Grande Panda (Type 326, 2024-present)
- Confirmed first generation: Type 141 (1980-2003, final production Sep 5, 2003)
- Confirmed second generation: Type 169 (May 2003-December 2012, 2,168,491 units)
- Confirmed third generation: Type 312 (2011-present)
- Updated README.md with standard template
- All data sourced from Wikipedia article: https://en.wikipedia.org/wiki/Fiat_Panda

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
